### PR TITLE
Fix Accidental Removal

### DIFF
--- a/Patches/DocWorld_Patches.xml
+++ b/Patches/DocWorld_Patches.xml
@@ -1627,9 +1627,6 @@
                     </li>
                 </operations>
             </match>
-            <nomatch Class="PatchOperationRemove">
-                <xpath>/Defs/ThingDef[defName="DZ_VFEPD_Bookshelf"]</xpath>
-            </nomatch>
         </match>
     </match>
 </Operation>


### PR DESCRIPTION
Pretty sure this is an accident, as it will always remove the bookshelf if you don't have RimFridge